### PR TITLE
Updated gr-baz formula

### DIFF
--- a/gr-baz.rb
+++ b/gr-baz.rb
@@ -12,8 +12,9 @@ class GrBaz < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
-    system "autoreconf -i"
-    system "./configure", *args
+    system "sh bootstrap"
+    system "sh configure", *args
+    system "make"
     system "make install"
   end
 end

--- a/gr-baz.rb
+++ b/gr-baz.rb
@@ -10,11 +10,41 @@ class GrBaz < Formula
   depends_on 'libusb'
   depends_on 'gnuradio'
 
+  def patches
+    DATA
+  end
+
   def install
     args = ["--prefix=#{prefix}"]
     system "sh bootstrap"
-    system "sh configure", *args
+    system "./configure", *args
     system "make"
     system "make install"
   end
 end
+
+__END__
+diff --git a/bootstrap b/bootstrap
+index 2412a7a..8f5799f 100644
+--- a/bootstrap
++++ b/bootstrap
+@@ -25,5 +25,5 @@ rm -fr config.cache autom4te*.cache
+ aclocal -I config
+ autoconf
+ autoheader
+-libtoolize --automake -c -f
++glibtoolize --automake -c -f
+ automake --add-missing -c -f -Wno-portability
+diff --git a/config/gr_standalone.m4 b/config/gr_standalone.m4
+index 35cb789..0ad91ce 100644
+--- a/config/gr_standalone.m4
++++ b/config/gr_standalone.m4
+@@ -29,7 +29,7 @@ dnl get called too late to be useful.
+ m4_define([GR_STANDALONE],
+ [
+   AC_CONFIG_SRCDIR([config/gr_standalone.m4])
+-  AM_CONFIG_HEADER(config.h)
++  AC_CONFIG_HEADER(config.h)
+ 
+   dnl Remember if the user explicity set CXXFLAGS
+   if test -n "${CXXFLAGS}"; then


### PR DESCRIPTION
Use bootstrap.sh instead of automake

Patches some build files to make it work w/ newer versions of automake. Only tested on 10.8 with up2date Xcode & automake installed via brew. These changes were necessary to make it build on my setup.
