### PR TITLE
Force use of apple-gcc42. fixes #32

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -43,6 +43,12 @@ class Gnuradio < Formula
   end
 
   def install
+
+	  # Force compilation with gcc-4.2
+	  ENV['CC'] = '/usr/local/bin/gcc-4.2'
+	  ENV['LD'] = '/usr/local/bin/gcc-4.2'
+	  ENV['CXX'] = '/usr/local/bin/g++-4.2'
+
     mkdir 'build' do
       args = ["-DCMAKE_PREFIX_PATH=#{prefix}", "-DQWT_INCLUDE_DIRS=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"] + std_cmake_args
       args << '-DENABLE_GR_QTGUI=OFF' unless ARGV.include?('--with-qt')

--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -6,7 +6,7 @@ class Gnuradio < Formula
   sha1 'ee4c40b366d94887511eefa6ce52df4bdbc9d105'
   head 'git://gnuradio.org/gnuradio.git'
 
-  depends_on 'apple-gcc4.2' => :build
+  depends_on 'apple-gcc42' => :build
   depends_on 'cmake' => :build
   depends_on 'Cheetah' => :python
   depends_on 'lxml' => :python

--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -6,6 +6,7 @@ class Gnuradio < Formula
   sha1 'ee4c40b366d94887511eefa6ce52df4bdbc9d105'
   head 'git://gnuradio.org/gnuradio.git'
 
+  depends_on 'apple-gcc4.2' => :build
   depends_on 'cmake' => :build
   depends_on 'Cheetah' => :python
   depends_on 'lxml' => :python

--- a/gr-baz.rb
+++ b/gr-baz.rb
@@ -12,8 +12,9 @@ class GrBaz < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
-    system "autoreconf -i"
-    system "./configure", *args
+    system "sh bootstrap"
+    system "sh configure", *args
+    system "make"
     system "make install"
   end
 end

--- a/gr-baz.rb
+++ b/gr-baz.rb
@@ -10,11 +10,41 @@ class GrBaz < Formula
   depends_on 'libusb'
   depends_on 'gnuradio'
 
+  def patches
+    DATA
+  end
+
   def install
     args = ["--prefix=#{prefix}"]
     system "sh bootstrap"
-    system "sh configure", *args
+    system "./configure", *args
     system "make"
     system "make install"
   end
 end
+
+__END__
+diff --git a/bootstrap b/bootstrap
+index 2412a7a..8f5799f 100644
+--- a/bootstrap
++++ b/bootstrap
+@@ -25,5 +25,5 @@ rm -fr config.cache autom4te*.cache
+ aclocal -I config
+ autoconf
+ autoheader
+-libtoolize --automake -c -f
++glibtoolize --automake -c -f
+ automake --add-missing -c -f -Wno-portability
+diff --git a/config/gr_standalone.m4 b/config/gr_standalone.m4
+index 35cb789..0ad91ce 100644
+--- a/config/gr_standalone.m4
++++ b/config/gr_standalone.m4
+@@ -29,7 +29,7 @@ dnl get called too late to be useful.
+ m4_define([GR_STANDALONE],
+ [
+   AC_CONFIG_SRCDIR([config/gr_standalone.m4])
+-  AM_CONFIG_HEADER(config.h)
++  AC_CONFIG_HEADER(config.h)
+ 
+   dnl Remember if the user explicity set CXXFLAGS
+   if test -n "${CXXFLAGS}"; then


### PR DESCRIPTION
Forcing use of apple-gcc42. 

gnuradio 3.6.1 cannot be compiled by system provided llvm.
By forcing apple-gcc42 we can build successfully.

fixes #32
